### PR TITLE
Make database parameter optional. (#22)

### DIFF
--- a/lib/AzureMySqlAction.js
+++ b/lib/AzureMySqlAction.js
@@ -29,7 +29,20 @@ class AzureMySqlAction {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug('Begin executing action...');
             let mySqlClientPath = yield AzureMySqlActionHelper_1.default.getMySqlClientPath();
-            yield exec.exec(`"${mySqlClientPath}" -h ${this._inputs.serverName} -D ${this._inputs.connectionString.database} -u ${this._inputs.connectionString.userId} ${this._inputs.additionalArguments} -e "source ${this._inputs.sqlFile}"`, [`--password=${this._inputs.connectionString.password}`]);
+            let parameters = [
+                "-h", this._inputs.serverName,
+                "-u", this._inputs.connectionString.userId,
+                "-e", `source ${this._inputs.sqlFile}`,
+            ];
+            if (this._inputs.connectionString.database) {
+                parameters.push("-D");
+                parameters.push(this._inputs.connectionString.database);
+            }
+            yield exec.exec(`"${mySqlClientPath}" ${this._inputs.additionalArguments}`, parameters, {
+                env: {
+                    "MYSQL_PWD": this._inputs.connectionString.password
+                }
+            });
             console.log('Successfully executed sql file on target database');
         });
     }

--- a/lib/MySqlConnectionStringBuilder.js
+++ b/lib/MySqlConnectionStringBuilder.js
@@ -101,8 +101,8 @@ class MySqlConnectionStringBuilder {
                 }
             }
         }
-        if (!parsedConnectionString.server || !parsedConnectionString.userId || !parsedConnectionString.password || !parsedConnectionString.database) {
-            throw new Error(`Missing required keys in connection string. Please ensure that the keys 'Server', 'User Id', 'Password', 'Database' are provided in the connection string.`);
+        if (!parsedConnectionString.server || !parsedConnectionString.userId || !parsedConnectionString.password) {
+            throw new Error(`Missing required keys in connection string. Please ensure that the keys 'Server', 'User Id', 'Password' are provided in the connection string.`);
         }
         return parsedConnectionString;
     }

--- a/lib/MySqlUtils.js
+++ b/lib/MySqlUtils.js
@@ -31,10 +31,13 @@ class MySqlUtils {
             try {
                 core.debug(`Validating if client has access to MySql Server '${serverName}'.`);
                 core.debug(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`);
-                yield exec.exec(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`, [`--password=${connectionString.password}`], {
+                yield exec.exec(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`, [], {
                     silent: true,
                     listeners: {
                         stderr: (data) => mySqlError += data.toString()
+                    },
+                    env: {
+                        "MYSQL_PWD": connectionString.password
                     }
                 });
             }

--- a/src/AzureMySqlAction.ts
+++ b/src/AzureMySqlAction.ts
@@ -17,9 +17,26 @@ export default class AzureMySqlAction {
 
     public async execute() {
         core.debug('Begin executing action...');
-        
+
         let mySqlClientPath = await AzureMySqlActionHelper.getMySqlClientPath();
-        await exec.exec(`"${mySqlClientPath}" -h ${this._inputs.serverName} -D ${this._inputs.connectionString.database} -u ${this._inputs.connectionString.userId} ${this._inputs.additionalArguments} -e "source ${this._inputs.sqlFile}"`, [`--password=${this._inputs.connectionString.password}`]);
+
+        let parameters = [
+            "-h", this._inputs.serverName,
+            "-u", this._inputs.connectionString.userId,
+            "-e", `source ${this._inputs.sqlFile}`,
+        ]
+
+        if (this._inputs.connectionString.database) {
+            parameters.push("-D")
+            parameters.push(this._inputs.connectionString.database)
+        }
+
+        await exec.exec(`"${mySqlClientPath}" ${this._inputs.additionalArguments}`,
+            parameters, {
+            env: {
+                "MYSQL_PWD": this._inputs.connectionString.password
+            }
+        });
         
         console.log('Successfully executed sql file on target database');
     }

--- a/src/MySqlConnectionStringBuilder.ts
+++ b/src/MySqlConnectionStringBuilder.ts
@@ -113,8 +113,8 @@ export default class MySqlConnectionStringBuilder {
             }
         }
 
-        if (!parsedConnectionString.server || !parsedConnectionString.userId || !parsedConnectionString.password || !parsedConnectionString.database) {
-            throw new Error(`Missing required keys in connection string. Please ensure that the keys 'Server', 'User Id', 'Password', 'Database' are provided in the connection string.`);
+        if (!parsedConnectionString.server || !parsedConnectionString.userId || !parsedConnectionString.password) {
+            throw new Error(`Missing required keys in connection string. Please ensure that the keys 'Server', 'User Id', 'Password' are provided in the connection string.`);
         }
 
         return parsedConnectionString;

--- a/src/MySqlUtils.ts
+++ b/src/MySqlUtils.ts
@@ -11,10 +11,13 @@ export default class MySqlUtils {
         try {
             core.debug(`Validating if client has access to MySql Server '${serverName}'.`);
             core.debug(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`);
-            await exec.exec(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`, [`--password=${connectionString.password}`], {
+            await exec.exec(`"${mySqlClientPath}" -h ${serverName} -u "${connectionString.userId}" -e "show databases"`, [], {
                 silent: true,
                 listeners: {
                     stderr: (data: Buffer) => mySqlError += data.toString()
+                },
+                env: {
+                    "MYSQL_PWD": connectionString.password
                 }
             });
         }


### PR DESCRIPTION
By making the database optional opens the scenario where we just want
to issue commands on the server (eg: to create a database),

- Fix: If the database name had spaces `mysql` call would fail
- Pass the password as an environment variable instead of command line.
Eliminates warning that password method passing is insecure.