### PR TITLE
Split authentication into parameter

### DIFF
--- a/__tests__/AzureMySqlAction.deprecated.test.ts
+++ b/__tests__/AzureMySqlAction.deprecated.test.ts
@@ -1,0 +1,86 @@
+import * as exec from '@actions/exec';
+import AzureMySqlActionHelper from '../src/AzureMySqlActionHelper';
+import MySqlConnectionStringBuilder from '../src/MySqlConnectionStringBuilder';
+import AzureMySqlAction, { IActionInputs } from '../src/AzureMySqlAction';
+
+describe('AzureMySqlAction.deprecated tests', () => {
+    it('executes sql file on target database', async () => {
+
+        let inputs = getInputs();
+        let action = new AzureMySqlAction(inputs);
+
+        let getMySqlClientPathSpy = jest.spyOn(AzureMySqlActionHelper, 'getMySqlClientPath').mockResolvedValue('mysql.exe');
+        let execSpy = jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+        await action.execute();
+
+        expect(getMySqlClientPathSpy).toHaveBeenCalledTimes(1);
+        expect(execSpy).toHaveBeenCalledTimes(1);
+        expect(execSpy).toHaveBeenCalledWith(`"mysql.exe" -t 10`,
+            [
+                "-h", "testmysqlserver.mysql.database.azure.com",
+                "-u", "testuser@testmysqlserver",
+                "-e", "source ./testsqlfile.sql",
+                "-D", "testdb"
+            ], {
+            env: {
+                "MYSQL_PWD": "testpassword"
+            }
+        })
+    })
+
+    it('executes sql file on target server', async () => {
+
+        let inputsNoDB = getInputsNoDatabase();
+        let action = new AzureMySqlAction(inputsNoDB);
+
+        let getMySqlClientPathSpy = jest.spyOn(AzureMySqlActionHelper, 'getMySqlClientPath').mockResolvedValue('mysql.exe');
+        let execSpy = jest.spyOn(exec, 'exec').mockResolvedValue(0);
+
+        await action.execute();
+
+        expect(getMySqlClientPathSpy).toHaveBeenCalledTimes(1);
+        expect(execSpy).toHaveBeenCalledTimes(1);
+        expect(execSpy).toHaveBeenCalledWith(`"mysql.exe" -t 10`,
+            [
+                "-h", "testmysqlserver.mysql.database.azure.com",
+                "-u", "testuser@testmysqlserver",
+                "-e", "source ./testsqlfile.sql"
+            ], {
+            env: {
+                "MYSQL_PWD": "testpassword"
+            }
+        })
+    })
+
+    it('throws if mysql client fails to execute', async () => {
+        let inputs = getInputs();
+        let action = new AzureMySqlAction(inputs);
+
+        let getMySqlClientPathSpy = jest.spyOn(AzureMySqlActionHelper, 'getMySqlClientPath').mockResolvedValue('mysql.exe');
+        let execSpy = jest.spyOn(exec, 'exec').mockRejectedValue(1);
+
+        expect.assertions(3);
+        await expect(action.execute()).rejects.toEqual(1);
+        expect(getMySqlClientPathSpy).toHaveBeenCalledTimes(1);
+        expect(execSpy).toHaveBeenCalledTimes(1);
+    })
+})
+
+function getInputs() {
+    return {
+        serverName: 'testmysqlserver.mysql.database.azure.com',
+        connectionString: new MySqlConnectionStringBuilder('Server=testmysqlserver.mysql.database.azure.com; Port=3306; Database=testdb; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'),
+        sqlFile: './testsqlfile.sql',
+        additionalArguments: '-t 10'
+    } as IActionInputs;
+}
+
+function getInputsNoDatabase() {
+    return {
+        serverName: 'testmysqlserver.mysql.database.azure.com',
+        connectionString: new MySqlConnectionStringBuilder('Server=testmysqlserver.mysql.database.azure.com; Port=3306; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'),
+        sqlFile: './testsqlfile.sql',
+        additionalArguments: '-t 10'
+    } as IActionInputs;
+}

--- a/__tests__/AzureMySqlAction.ng.test.ts
+++ b/__tests__/AzureMySqlAction.ng.test.ts
@@ -3,7 +3,7 @@ import AzureMySqlActionHelper from '../src/AzureMySqlActionHelper';
 import MySqlConnectionStringBuilder from '../src/MySqlConnectionStringBuilder';
 import AzureMySqlAction, { IActionInputs } from '../src/AzureMySqlAction';
 
-describe('AzureMySqlAction tests', () => {
+describe('AzureMySqlAction.ng tests', () => {
     it('executes sql file on target database', async () => {
 
         let inputs = getInputs();
@@ -70,7 +70,12 @@ describe('AzureMySqlAction tests', () => {
 function getInputs() {
     return {
         serverName: 'testmysqlserver.mysql.database.azure.com',
-        connectionString: new MySqlConnectionStringBuilder('Server=testmysqlserver.mysql.database.azure.com; Port=3306; Database=testdb; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'),
+        connectionString: {
+            server: 'testmysqlserver.mysql.database.azure.com',
+            userId: 'testuser@testmysqlserver',
+            password: 'testpassword',
+            database: 'testdb'
+        },
         sqlFile: './testsqlfile.sql',
         additionalArguments: '-t 10'
     } as IActionInputs;
@@ -79,7 +84,11 @@ function getInputs() {
 function getInputsNoDatabase() {
     return {
         serverName: 'testmysqlserver.mysql.database.azure.com',
-        connectionString: new MySqlConnectionStringBuilder('Server=testmysqlserver.mysql.database.azure.com; Port=3306; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'),
+        connectionString: {
+            server: 'testmysqlserver.mysql.database.azure.com',
+            userId: 'testuser@testmysqlserver',
+            password: 'testpassword'
+        },
         sqlFile: './testsqlfile.sql',
         additionalArguments: '-t 10'
     } as IActionInputs;

--- a/__tests__/getInputMockHelper.ts
+++ b/__tests__/getInputMockHelper.ts
@@ -1,0 +1,17 @@
+import * as core from '@actions/core';
+
+export function getInputMock(core, inputs: Map<string, string>) {
+
+    return jest.spyOn(core, 'getInput').mockImplementation((name, options): string => {
+
+        if (inputs.has(name as string)) {
+            return inputs.get(name as string) as string
+        }
+
+        if (options && (options as core.InputOptions).required) {
+            throw new Error('Input required and not supplied: missing')
+        }
+
+        return '';
+    });
+}

--- a/__tests__/main.ng.test.ts
+++ b/__tests__/main.ng.test.ts
@@ -1,0 +1,251 @@
+import * as core from '@actions/core';
+
+import { run } from "../src/main";
+import { AuthorizerFactory } from 'azure-actions-webclient/AuthorizerFactory';
+
+import AzureMySqlAction from '../src/AzureMySqlAction';
+import AzureMySqlActionHelper from '../src/AzureMySqlActionHelper';
+import MySqlConnectionStringBuilder from '../src/MySqlConnectionStringBuilder';
+import FirewallManager from '../src/FirewallManager';
+import AzureMySqlResourceManager from '../src/AzureMySqlResourceManager';
+import MySqlUtils from '../src/MySqlUtils';
+
+import { getInputMock } from './getInputMockHelper'
+
+jest.mock('@actions/core');
+jest.mock('azure-actions-webclient/AuthorizerFactory');
+jest.mock('../src/AzureMySqlAction');
+jest.mock('../src/FirewallManager');
+jest.mock('../src/AzureMySqlResourceManager');
+
+jest.mock('../src/MySqlConnectionStringBuilder', () => {
+    return jest.fn().mockImplementation(() => {
+        return {
+            server: 'testmysqlserver.mysql.database.azure.com'
+        }
+    })
+});
+
+describe('main.ng.ts tests', () => {
+    it('gets inputs and runs sql file', async () => {
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                [ 'username', 'testuser@testmysqlserver'],
+                [ 'password', 'testpassword'],
+                [ 'database', 'testdb'],
+                ['sql-file', './testsqlfile.sql'],
+                ['arguments', '-t 10']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.sql');
+        let getResourceManagerSpy = jest.spyOn(AzureMySqlResourceManager, 'getResourceManager');
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).toHaveBeenCalled();
+        expect(detectIPAddressSpy).toHaveBeenCalled();
+        expect(getAuthorizerSpy).not.toHaveBeenCalled();
+        expect(getInputSpy).toHaveBeenCalled();
+        expect(getResourceManagerSpy).not.toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).not.toHaveBeenCalled();
+        expect(resolveFilePathSpy).toHaveBeenCalled();
+        expect(addFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(actionExecuteSpy).toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(setFailedSpy).not.toHaveBeenCalled();
+    })
+
+    it('throws error if sql file path is invalid', async () => {
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                [ 'username', 'testuser@testmysqlserver'],
+                [ 'password', 'testpassword'],
+                [ 'database', 'testdb'],
+                ['sql-file', './testsqlfile.sql'],
+                ['arguments', '-t 10']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.random');
+
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).not.toHaveBeenCalled();
+        expect(detectIPAddressSpy).not.toHaveBeenCalled();
+        expect(getAuthorizerSpy).not.toHaveBeenCalled();
+        expect(addFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(actionExecuteSpy).not.toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).not.toHaveBeenCalled();
+
+        expect(resolveFilePathSpy).toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).not.toHaveBeenCalled();
+        expect(setFailedSpy).toHaveBeenCalledWith('Invalid sql file path provided as input ./testsqlfile.random');
+    });
+
+    it('add firewall rule when its not already configured', async () => {
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                ['connection-string', 'testmysqlserver.mysql.database.azure.com; Port=3306; Database=testdb; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'],
+                ['sql-file', './testsqlfile.sql'],
+                ['arguments', '-t 10']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.sql');
+        let getResourceManagerSpy = jest.spyOn(AzureMySqlResourceManager, 'getResourceManager');
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "1.2.3.4";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).toHaveBeenCalled();
+        expect(detectIPAddressSpy).toHaveBeenCalled();
+        expect(getAuthorizerSpy).toHaveBeenCalled();
+        expect(getInputSpy).toHaveBeenCalled();
+        expect(getResourceManagerSpy).toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).toHaveBeenCalled();
+        expect(resolveFilePathSpy).toHaveBeenCalled();
+        expect(addFirewallRuleSpy).toHaveBeenCalled();
+        expect(actionExecuteSpy).toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).toHaveBeenCalled();
+        expect(setFailedSpy).not.toHaveBeenCalled();
+    });
+
+    it('cannot specify username and connection string same time', async () => {
+
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                ['username', 'testuser@testmysqlserver'],
+                ['password', 'testpassword'],
+                ['database', 'testdb'],
+                ['connection-string', 'testmysqlserver.mysql.database.azure.com; Port=3306; Database=testdb; Uid=testuser@testmysqlserver; Pwd=testpassword; SslMode=Preferred'],
+                ['sql-file', './testsqlfile.sql'],
+                ['arguments', '-t 10']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.sql');
+        let getResourceManagerSpy = jest.spyOn(AzureMySqlResourceManager, 'getResourceManager');
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).not.toHaveBeenCalled();
+        expect(detectIPAddressSpy).not.toHaveBeenCalled();
+        expect(getAuthorizerSpy).not.toHaveBeenCalled();
+        expect(getInputSpy).toHaveBeenCalled();
+        expect(getResourceManagerSpy).not.toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).not.toHaveBeenCalled();
+        expect(resolveFilePathSpy).not.toHaveBeenCalled();
+        expect(addFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(actionExecuteSpy).not.toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(setFailedSpy).toHaveBeenCalledWith('Cannot specify both username and connection string');
+    })
+
+    it('Need to specify at least one auth definition', async () => {
+
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                ['sql-file', './testsqlfile.sql'],
+                ['arguments', '-t 10']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.sql');
+        let getResourceManagerSpy = jest.spyOn(AzureMySqlResourceManager, 'getResourceManager');
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).not.toHaveBeenCalled();
+        expect(detectIPAddressSpy).not.toHaveBeenCalled();
+        expect(getAuthorizerSpy).not.toHaveBeenCalled();
+        expect(getInputSpy).toHaveBeenCalled();
+        expect(getResourceManagerSpy).not.toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).not.toHaveBeenCalled();
+        expect(resolveFilePathSpy).not.toHaveBeenCalled();
+        expect(addFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(actionExecuteSpy).not.toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(setFailedSpy).toHaveBeenCalledWith('Need to specify either username and password or connection-string');
+    })
+
+    it('Password not specified', async () => {
+
+        const getInputSpy = getInputMock(core,
+            new Map([
+                ['server-name', 'testmysqlserver.mysql.database.azure.com'],
+                ['username', 'testuser@testmysqlserver']
+            ])
+        );
+
+        let resolveFilePathSpy = jest.spyOn(AzureMySqlActionHelper, 'resolveFilePath').mockReturnValue('./testsqlfile.sql');
+        let getResourceManagerSpy = jest.spyOn(AzureMySqlResourceManager, 'getResourceManager');
+        let getAuthorizerSpy = jest.spyOn(AuthorizerFactory, 'getAuthorizer');
+        let addFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'addFirewallRule');
+        let actionExecuteSpy = jest.spyOn(AzureMySqlAction.prototype, 'execute');
+        let removeFirewallRuleSpy = jest.spyOn(FirewallManager.prototype, 'removeFirewallRule');
+        let setFailedSpy = jest.spyOn(core, 'setFailed');
+        let detectIPAddressSpy = MySqlUtils.detectIPAddress = jest.fn().mockImplementationOnce(() => {
+            return "";
+        });
+
+        await run();
+
+        expect(AzureMySqlAction).not.toHaveBeenCalled();
+        expect(detectIPAddressSpy).not.toHaveBeenCalled();
+        expect(getAuthorizerSpy).not.toHaveBeenCalled();
+        expect(getInputSpy).toHaveBeenCalled();
+        expect(getResourceManagerSpy).not.toHaveBeenCalled();
+        expect(MySqlConnectionStringBuilder).not.toHaveBeenCalled();
+        expect(resolveFilePathSpy).not.toHaveBeenCalled();
+        expect(addFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(actionExecuteSpy).not.toHaveBeenCalled();
+        expect(removeFirewallRuleSpy).not.toHaveBeenCalled();
+        expect(setFailedSpy).toHaveBeenCalledWith('Input required and not supplied: missing');
+    })
+})

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,17 @@ inputs:
     description: 'Server name of Azure DB for Mysql. Example: fabrikam.mysql.database.azure.com. When you connect using Mysql Workbench, this is the same value that is used for Hostname in Parameters'
     required: true
   connection-string:
-    description: 'The connection string, including authentication information, for the Azure MySQL Server.'
-    required: true
+    description: 'The connection string, including authentication information, for the Azure MySQL Server. (deprecated)'
+    required: false
+  username:
+    description: 'Azure MySQL Server username for login'
+    required: false
+  password:
+      description: 'Azure MySQL Server password for login'
+      required: false
+  database:
+    description: 'Azure MySQL Server database (optional) to connect to. No database will be used automatically.'
+    required: false    
   sql-file:
     description: 'Path to SQL script file, *.sql to deploy'
     required: true

--- a/lib/MySqlConnectionString.js
+++ b/lib/MySqlConnectionString.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,17 +64,36 @@ function run() {
 exports.run = run;
 function getInputs() {
     let serverName = core.getInput('server-name', { required: true });
-    let connectionString = core.getInput('connection-string', { required: true });
-    let connectionStringBuilder = new MySqlConnectionStringBuilder_1.default(connectionString);
-    let sqlFile = AzureMySqlActionHelper_1.default.resolveFilePath(core.getInput('sql-file', { required: true }));
+    // Support both auth methods. Passing all parameters (login,pwd,db) or the legacy connection string
+    const connectionString = core.getInput('connection-string', { required: false });
+    const username = core.getInput('username', { required: false });
+    if (username && username !== '' && connectionString && connectionString !== '') {
+        throw new Error('Cannot specify both username and connection string');
+    }
+    let connectionStringBuilder;
+    if (username && username !== '') {
+        connectionStringBuilder = {
+            server: serverName,
+            userId: username,
+            password: core.getInput('password', { required: true }),
+            database: core.getInput('database', { required: false })
+        };
+    }
+    else if (!connectionString || connectionString === '') {
+        throw new Error('Need to specify either username and password or connection-string');
+    }
+    else { // use deprecated connection string
+        connectionStringBuilder = new MySqlConnectionStringBuilder_1.default(connectionString);
+        // validate that the server name input matches the connection string server name
+        if (serverName.toLowerCase() !== connectionStringBuilder.server.toLowerCase()) {
+            throw new Error('Server name mismatch error. The server name provided in the action input does not match the server name provided in the connection string.');
+        }
+    }
+    const sqlFile = AzureMySqlActionHelper_1.default.resolveFilePath(core.getInput('sql-file', { required: true }));
     if (path.extname(sqlFile).toLowerCase() !== '.sql') {
         throw new Error(`Invalid sql file path provided as input ${sqlFile}`);
     }
-    // validate that the sever name input matches the connection string server name
-    if (serverName.toLowerCase() !== connectionStringBuilder.server.toLowerCase()) {
-        throw new Error(`Server name mismatch error. The server name provided in the action input does not match the server name provided in the connection string.`);
-    }
-    let additionalArguments = core.getInput('arguments');
+    const additionalArguments = core.getInput('arguments');
     return {
         serverName: serverName,
         connectionString: connectionStringBuilder,

--- a/src/AzureMySqlAction.ts
+++ b/src/AzureMySqlAction.ts
@@ -1,11 +1,12 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import AzureMySqlActionHelper from './AzureMySqlActionHelper';
+import { MySqlConnectionString } from './MySqlConnectionString';
 import MySqlConnectionStringBuilder from './MySqlConnectionStringBuilder';
 
 export interface IActionInputs {
     serverName: string;
-    connectionString: MySqlConnectionStringBuilder;
+    connectionString: MySqlConnectionString;
     sqlFile: string;
     additionalArguments: string;
 }

--- a/src/MySqlConnectionString.ts
+++ b/src/MySqlConnectionString.ts
@@ -1,0 +1,7 @@
+
+export interface MySqlConnectionString {
+    server: string;
+    userId: string;
+    password: string;
+    database: string | null | undefined;
+}

--- a/src/MySqlConnectionStringBuilder.ts
+++ b/src/MySqlConnectionStringBuilder.ts
@@ -20,24 +20,18 @@
     where KeyValueRegex = ([\w\s]+=(?:('[^']*(''[^']*)*')|("[^"]*(""[^"]*)*")|((?!['"])[^;]*))))
 */
 import * as core from '@actions/core';
+import { MySqlConnectionString } from './MySqlConnectionString';
 
 const connectionStringParserRegex = /(?<key>[\w\s]+)=(?<val>('[^']*(''[^']*)*')|("[^"]*(""[^"]*)*")|((?!['"])[^;]*))/g 
 const connectionStringTester = /^[;\s]*([\w\s]+=(?:('[^']*(''[^']*)*')|("[^"]*(""[^"]*)*")|((?!['"])[^;]*)))(;[;\s]*([\w\s]+=(?:('[^']*(''[^']*)*')|("[^"]*(""[^"]*)*")|((?!['"])[^;]*))))*[;\s]*$/
 
-export interface MySqlConnectionString {
-    server: string;
-    userId: string;
-    password: string;
-    database: string;
-}
-
-export default class MySqlConnectionStringBuilder {
+export default class MySqlConnectionStringBuilder implements MySqlConnectionString {
     constructor(connectionString: string) {
         this._connectionString = connectionString;
         this._validateConnectionString();
         this._parsedConnectionString = this._parseConnectionString();
     }
-    
+
     public get connectionString(): string {
         return this._connectionString;
     }
@@ -54,7 +48,7 @@ export default class MySqlConnectionStringBuilder {
         return this._parsedConnectionString.server;
     }
 
-    public get database(): string {
+    public get database(): string | null | undefined {
         return this._parsedConnectionString.database;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import FirewallManager from './FirewallManager';
 import AzureMySqlResourceManager from './AzureMySqlResourceManager';
 import MySqlConnectionStringBuilder from './MySqlConnectionStringBuilder';
 import MySqlUtils from './MySqlUtils';
+import { MySqlConnectionString } from './MySqlConnectionString';
 
 let userAgentPrefix = !!process.env.AZURE_HTTP_USER_AGENT ? `${process.env.AZURE_HTTP_USER_AGENT}` : "";
 
@@ -24,7 +25,7 @@ export async function run() {
         let inputs = getInputs();
         let azureMySqlAction = new AzureMySqlAction(inputs);
         const runnerIPAddress = await MySqlUtils.detectIPAddress(inputs.serverName, inputs.connectionString);
-        if(runnerIPAddress) {
+        if (runnerIPAddress) {
             let azureResourceAuthorizer = await AuthorizerFactory.getAuthorizer();
             let azureMySqlResourceManager = await AzureMySqlResourceManager.getResourceManager(inputs.serverName, azureResourceAuthorizer);
             firewallManager = new FirewallManager(azureMySqlResourceManager);
@@ -32,7 +33,7 @@ export async function run() {
         }
         await azureMySqlAction.execute();
     }
-    catch(error) {
+    catch (error) {
         core.setFailed(error.message);
     }
     finally {
@@ -47,27 +48,49 @@ export async function run() {
 
 function getInputs(): IActionInputs {
     let serverName = core.getInput('server-name', { required: true });
-    
-    let connectionString = core.getInput('connection-string', { required: true });
-    let connectionStringBuilder = new MySqlConnectionStringBuilder(connectionString);
-    
-    let sqlFile = AzureMySqlActionHelper.resolveFilePath(core.getInput('sql-file', { required: true }));
+
+    // Support both auth methods. Passing all parameters (login,pwd,db) or the legacy connection string
+    const connectionString = core.getInput('connection-string', { required: false });
+    const username = core.getInput('username', { required: false });
+
+    if (username && username !== '' && connectionString && connectionString !== '') {
+        throw new Error('Cannot specify both username and connection string')
+    }
+
+    let connectionStringBuilder: MySqlConnectionString
+
+    if (username && username !== '') {
+
+        connectionStringBuilder = {
+            server: serverName,
+            userId: username,
+            password: core.getInput('password', { required: true }),
+            database: core.getInput('database', { required: false })
+        }
+    } else if (!connectionString || connectionString === '') {
+        throw new Error('Need to specify either username and password or connection-string')
+    } else { // use deprecated connection string
+        connectionStringBuilder = new MySqlConnectionStringBuilder(connectionString);
+
+        // validate that the server name input matches the connection string server name
+        if (serverName.toLowerCase() !== connectionStringBuilder.server.toLowerCase()) {
+            throw new Error('Server name mismatch error. The server name provided in the action input does not match the server name provided in the connection string.');
+        }
+    }
+
+    const sqlFile = AzureMySqlActionHelper.resolveFilePath(core.getInput('sql-file', { required: true }));
+
     if (path.extname(sqlFile).toLowerCase() !== '.sql') {
         throw new Error(`Invalid sql file path provided as input ${sqlFile}`);
     }
 
-    // validate that the sever name input matches the connection string server name
-    if (serverName.toLowerCase() !== connectionStringBuilder.server.toLowerCase()) {
-        throw new Error(`Server name mismatch error. The server name provided in the action input does not match the server name provided in the connection string.`);
-    }
+    const additionalArguments = core.getInput('arguments');
 
-    let additionalArguments = core.getInput('arguments');
-    
     return {
         serverName: serverName,
         connectionString: connectionStringBuilder,
         sqlFile: sqlFile,
-        additionalArguments: additionalArguments   
+        additionalArguments: additionalArguments
     };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,5 +60,5 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "__tests__/**","**/*.test.ts"]
 }


### PR DESCRIPTION
Split up the connection string blob components into individual parameters for easier use of the action.

By having individual units the workflow is

- More readable
  - parameters are not hidden in a opaque blob stored as a secret)
- Easier to write and manage
  - No need to use a secret to store all parameters
  - When it needs to be changed password is not mixed with other data 
  - No need to manually construct a connection string
  - By having smaller units it's easier to reuse them in other parts of the workflow (e.g.: Infrastructure as code or web apps parameters)

- The authentication and database settings are now passed to the action as individual parameters:
  - username
  - password
  - database (optional)

`connection-string` is now considered deprecated but still supported to keep backwards compatibility, user can either use individual parameters or `connection-string` (but not mix them)

Tests have been separated into `deprecated` and `ng` in case deprecation results in removal of `connection-string` support in the future.